### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: billymfl/test-actions/mydocker:v1
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore